### PR TITLE
Fix Anomaly timestamp parameter syntax

### DIFF
--- a/src/main/kotlin/br/com/gbanomalytracker/entity/Anomaly.kt
+++ b/src/main/kotlin/br/com/gbanomalytracker/entity/Anomaly.kt
@@ -25,7 +25,7 @@ data class Anomaly(
         description = "Data e hora em que a anomalia foi detectada",
         example = "2023-06-27T12:00:00",
     )
-    var timestamp: LocalDateTime = LocalDateTime.now(),
+    var timestamp: LocalDateTime = LocalDateTime.now()
 
     )
 


### PR DESCRIPTION
## Summary
- remove trailing comma from `Anomaly` constructor

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843916336708325b7cffcbb706f340c